### PR TITLE
Update format.yml

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Ultralytics Formatting
-        uses: ultralytics/actions@fetch-depth
+        uses: ultralytics/actions@glenn-jocher-patch-2
         with:
           token: ${{ secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN}}
           labels: true # autolabel issues and PRs


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated a GitHub Actions workflow to use a specific branch of the `ultralytics/actions` repository.

### 📊 Key Changes  
- 🛠 Changed the GitHub Actions workflow configuration to use `ultralytics/actions@glenn-jocher-patch-2` instead of `ultralytics/actions@fetch-depth`.

### 🎯 Purpose & Impact  
- 🎯 **Purpose**: Ensures the workflow uses a specific branch (`glenn-jocher-patch-2`), likely to test or benefit from updated or experimental features in that branch.  
- 🚀 **Impact**: This change aligns the GitHub workflow with ongoing development, which may improve automation reliability. Users may notice smoother issue/PR labeling processes in the repository.